### PR TITLE
improve error message

### DIFF
--- a/lib/lyex/parser/operations.ex
+++ b/lib/lyex/parser/operations.ex
@@ -154,7 +154,7 @@ defmodule Lyex.Parser.Operations do
 
     case type do
       nil ->
-        raise "Unable to find type '#{type}'"
+        raise "Unable to find type '#{name}'"
 
       %{elements: elements} = type ->
         elements = Enum.map(elements, &resolve_element_type(&1, definition))


### PR DESCRIPTION
This gives a better error message when types are not found.

Which is an error I encounter when I try to parse this WSDL:

    http://vinsearch.eurotaxglass.com/vin-intl/?wsdl

with this PR, it says:

    ** (RuntimeError) Unable to find type 'string'

I am not familiar with SOAP at all, but this looks like a default type that should be supported?